### PR TITLE
fix: elasped endless loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ tokio = { version = "1", features = ["macros", "net", "rt", "sync", "time"] }
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots", "url"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util"] }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -238,25 +238,39 @@ impl<S: Send + Sync + ?Sized + 'static> Bot<S> {
     /// calling the appropriate method for each message that comes in.
     async fn handle<H: RaceHandler<S>>(mut stream: WsStream, network_timeout: Option<UDuration>, ctx: RaceContext<S>, data: &Mutex<BotData>) -> Result<(), HandleError<H::Error>> {
         async fn reconnect<S: Send + Sync + ?Sized, E>(last_network_error: &mut Instant, reconnect_wait_time: &mut UDuration, stream: &mut WsStream, network_timeout: Option<UDuration>, ctx: &RaceContext<S>, data: &Mutex<BotData>, reason: &str) -> Result<(), HandleErrorKind<E>> {
+            enum ReconnectAttemptError {
+                Connect(io::Error),
+                WebSocket(tungstenite::Error),
+            }
+
             let ws_conn = loop {
                 if last_network_error.elapsed() >= UDuration::from_hours(24) {
                     *reconnect_wait_time = UDuration::from_secs(1); // reset wait time after no crash for a day
                 } else {
-                    *reconnect_wait_time *= 2; // exponential backoff
+                    *reconnect_wait_time = reconnect_wait_time.saturating_mul(2).min(UDuration::from_mins(5)); // exponential backoff
                 }
                 eprintln!("{reason}, reconnecting in {reconnect_wait_time:?}…");
                 sleep(*reconnect_wait_time).await;
                 *last_network_error = Instant::now();
-                let data = data.lock().await;
-                let mut request = data.host_info.websocket_uri(&ctx.data().await.websocket_bot_url)?.into_client_request()?;
+                let (host_info, access_token) = {
+                    let data = data.lock().await;
+                    (data.host_info.clone(), data.access_token.clone())
+                };
+                let mut request = host_info.websocket_uri(&ctx.data().await.websocket_bot_url)?.into_client_request()?;
                 request.headers_mut().append(
                     http::header::HeaderName::from_static("authorization"),
-                    format!("Bearer {}", data.access_token).parse::<http::header::HeaderValue>()?,
+                    format!("Bearer {access_token}").parse::<http::header::HeaderValue>()?,
                 );
-                match tokio_tungstenite::client_async_tls(request, maybe_timeout(network_timeout, TcpStream::connect(data.host_info.websocket_socketaddrs())).await?.map_err(HandleErrorKind::Connect)?).await {
-                    Ok((ws_conn, _)) => break ws_conn,
-                    Err(tungstenite::Error::Http(response)) if response.status().is_server_error() => continue,
-                    Err(e) => return Err(e.into()),
+                match maybe_timeout(network_timeout, async {
+                    let tcp_stream = TcpStream::connect(host_info.websocket_socketaddrs()).await.map_err(ReconnectAttemptError::Connect)?;
+                    tokio_tungstenite::client_async_tls(request, tcp_stream).await
+                        .map(|(ws_conn, _)| ws_conn)
+                        .map_err(ReconnectAttemptError::WebSocket)
+                }).await {
+                    Ok(Ok(ws_conn)) => break ws_conn,
+                    Ok(Err(ReconnectAttemptError::Connect(e))) => eprintln!("WebSocket reconnect attempt failed to connect: {e}"),
+                    Ok(Err(ReconnectAttemptError::WebSocket(e))) => eprintln!("WebSocket reconnect attempt failed: {e}"),
+                    Err(Elapsed { .. }) => eprintln!("WebSocket reconnect attempt timed out"),
                 }
             };
             (*ctx.sender.lock().await, *stream) = ws_conn.split();
@@ -265,10 +279,12 @@ impl<S: Send + Sync + ?Sized + 'static> Bot<S> {
 
         let mut last_network_error = Instant::now();
         let mut reconnect_wait_time = UDuration::from_secs(1);
+        let mut waiting_for_probe_response = false;
         let mut handler = H::new(&ctx).await.h_at(HandleErrorContext::New)?;
         loop {
             match maybe_timeout(network_timeout, stream.next()).await {
                 Ok(Some(Ok(tungstenite::Message::Text(buf)))) => {
+                    waiting_for_probe_response = false;
                     match serde_json::from_str(&buf).at(HandleErrorContext::Decode)? {
                         Message::ChatHistory { messages } => handler.chat_history(&ctx, messages).await.h_at(HandleErrorContext::ChatHistory)?,
                         Message::ChatMessage { message } => handler.chat_message(&ctx, message).await.h_at(HandleErrorContext::ChatMessage)?,
@@ -294,31 +310,68 @@ impl<S: Send + Sync + ?Sized + 'static> Bot<S> {
                     }
                 }
                 Ok(Some(Ok(tungstenite::Message::Ping(payload)))) => {
+                    waiting_for_probe_response = false;
                     maybe_timeout(network_timeout, ctx.sender.lock().await.send(tungstenite::Message::Pong(payload))).await.at(HandleErrorContext::Ping)?.at(HandleErrorContext::Ping)?;
                     // chat stops working 1 hour after race ends, allow the handler to stop then by periodically rechecking should_stop
                     if handler.should_stop(&ctx).await.h_at(HandleErrorContext::ShouldStop)? {
                         return handler.end(&ctx).await.h_at(HandleErrorContext::End)
                     }
                 }
-                Ok(Some(Ok(tungstenite::Message::Close(Some(tungstenite::protocol::CloseFrame { reason, .. }))))) if matches!(&*reason, "CloudFlare WebSocket proxy restarting" | "keepalive ping timeout") => reconnect(
-                    &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
-                    "WebSocket connection closed by server",
-                ).await.at(HandleErrorContext::Reconnect)?,
+                Ok(Some(Ok(tungstenite::Message::Pong(_)))) => waiting_for_probe_response = false,
+                Ok(Some(Ok(tungstenite::Message::Close(Some(tungstenite::protocol::CloseFrame { reason, .. }))))) if matches!(&*reason, "CloudFlare WebSocket proxy restarting" | "keepalive ping timeout") => {
+                    reconnect(
+                        &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                        "WebSocket connection closed by server",
+                    ).await.at(HandleErrorContext::Reconnect)?;
+                    waiting_for_probe_response = false;
+                }
                 Ok(Some(Ok(msg))) => return Err(HandleErrorKind::UnexpectedMessageType(msg)).at(HandleErrorContext::Recv),
-                Ok(Some(Err(tungstenite::Error::Io(e)))) if matches!(e.kind(), io::ErrorKind::ConnectionReset | io::ErrorKind::UnexpectedEof) => reconnect( //TODO other error kinds?
-                    &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
-                    "unexpected end of file while waiting for message from server",
-                ).await.at(HandleErrorContext::Reconnect)?,
-                Ok(Some(Err(tungstenite::Error::Protocol(tungstenite::error::ProtocolError::ResetWithoutClosingHandshake)))) => reconnect(
-                    &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
-                    "connection reset without closing handshake while waiting for message from server",
-                ).await.at(HandleErrorContext::Reconnect)?,
+                Ok(Some(Err(tungstenite::Error::Io(e)))) if matches!(e.kind(), io::ErrorKind::ConnectionReset | io::ErrorKind::UnexpectedEof) => {
+                    reconnect( //TODO other error kinds?
+                        &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                        "unexpected end of file while waiting for message from server",
+                    ).await.at(HandleErrorContext::Reconnect)?;
+                    waiting_for_probe_response = false;
+                }
+                Ok(Some(Err(tungstenite::Error::Protocol(tungstenite::error::ProtocolError::ResetWithoutClosingHandshake)))) => {
+                    reconnect(
+                        &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                        "connection reset without closing handshake while waiting for message from server",
+                    ).await.at(HandleErrorContext::Reconnect)?;
+                    waiting_for_probe_response = false;
+                }
                 Ok(Some(Err(e))) => return Err(e).at(HandleErrorContext::Recv),
                 Ok(None) => return Err(HandleErrorKind::EndOfStream).at(HandleErrorContext::Recv),
                 Err(Elapsed { .. }) => {
                     // chat stops working 1 hour after race ends, allow the handler to stop then by periodically rechecking should_stop
                     if handler.should_stop(&ctx).await.h_at(HandleErrorContext::ShouldStop)? {
                         return handler.end(&ctx).await.h_at(HandleErrorContext::End)
+                    }
+                    if waiting_for_probe_response {
+                        reconnect(
+                            &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                            "no response to WebSocket liveness probe",
+                        ).await.at(HandleErrorContext::Reconnect)?;
+                        waiting_for_probe_response = false;
+                    } else {
+                        match maybe_timeout(network_timeout, ctx.sender.lock().await.send(tungstenite::Message::Ping(Default::default()))).await {
+                            Ok(Ok(())) => waiting_for_probe_response = true,
+                            Ok(Err(e)) => {
+                                let reason = format!("failed to send WebSocket liveness probe: {e}");
+                                reconnect(
+                                    &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                                    &reason,
+                                ).await.at(HandleErrorContext::Reconnect)?;
+                                waiting_for_probe_response = false;
+                            }
+                            Err(Elapsed { .. }) => {
+                                reconnect(
+                                    &mut last_network_error, &mut reconnect_wait_time, &mut stream, network_timeout, &ctx, data,
+                                    "timed out sending WebSocket liveness probe",
+                                ).await.at(HandleErrorContext::Reconnect)?;
+                                waiting_for_probe_response = false;
+                            }
+                        }
                     }
                 }
             }
@@ -369,9 +422,9 @@ impl<S: Send + Sync + ?Sized + 'static> Bot<S> {
                 let name = name.to_owned();
                 let data_clone = Arc::clone(&self.data);
                 H::task(Arc::clone(&self.state), race_data, tokio::spawn(async move {
-                    Self::handle::<H>(stream, network_timeout, ctx, &data_clone).await?;
+                    let result = Self::handle::<H>(stream, network_timeout, ctx, &data_clone).await;
                     data_clone.lock().await.handled_races.remove(&name);
-                    Ok(())
+                    result
                 })).await.map_err(RunError::Handler)?;
             }
         }
@@ -451,5 +504,283 @@ impl<S: Send + Sync + ?Sized + 'static> Bot<S> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        std::{
+            borrow::Cow,
+            num::NonZeroU16,
+            sync::{
+                Arc,
+                atomic::{
+                    AtomicBool,
+                    Ordering,
+                },
+            },
+        },
+        async_trait::async_trait,
+        futures::{
+            SinkExt as _,
+            StreamExt as _,
+        },
+        tokio::{
+            net::TcpListener,
+            time::advance,
+        },
+        tokio_tungstenite::{
+            accept_async,
+            connect_async,
+            tungstenite,
+        },
+        crate::handler::ServerErrors,
+        super::*,
+    };
+
+    #[derive(Default)]
+    struct TestState {
+        ended: AtomicBool,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("test handler error")]
+    struct TestHandlerError;
+
+    impl From<ServerErrors> for TestHandlerError {
+        fn from(_: ServerErrors) -> Self {
+            Self
+        }
+    }
+
+    struct TestHandler;
+
+    #[async_trait]
+    impl RaceHandler<TestState> for TestHandler {
+        type Error = TestHandlerError;
+
+        async fn new(_: &RaceContext<TestState>) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+
+        async fn end(self, ctx: &RaceContext<TestState>) -> Result<(), Self::Error> {
+            ctx.global_state.ended.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn race_data_json(status: &str) -> serde_json::Value {
+        let mut data = serde_json::Map::new();
+        for part in [
+            serde_json::json!({
+                "version": 1,
+                "name": "test/test-room",
+                "slug": "test-room",
+                "category": {
+                    "name": "Test",
+                    "short_name": "Test",
+                    "slug": "test",
+                    "url": "/test",
+                    "data_url": "/test/data"
+                },
+                "status": {
+                    "value": status,
+                    "verbose_value": status,
+                    "help_text": ""
+                },
+                "url": "/test/test-room",
+                "data_url": "/test/test-room/data",
+                "websocket_url": "/ws",
+                "websocket_bot_url": "/ws",
+                "websocket_oauth_url": "/ws",
+                "goal": {
+                    "name": "Test",
+                    "custom": false
+                },
+                "info": "",
+                "info_bot": null,
+                "info_user": null
+            }),
+            serde_json::json!({
+                "entrants_count": 0,
+                "entrants_count_finished": 0,
+                "entrants_count_inactive": 0,
+                "entrants": [],
+                "opened_at": "2026-01-01T00:00:00Z",
+                "start_delay": "P0DT0H0M0S",
+                "started_at": null,
+                "ended_at": if status == "finished" { Some("2026-01-01T01:00:00Z") } else { None },
+                "cancelled_at": null,
+                "ranked": false,
+                "unlisted": false,
+                "time_limit": "P0DT24H0M0S",
+                "time_limit_auto_complete": false,
+                "require_even_teams": false,
+                "streaming_required": false
+            }),
+            serde_json::json!({
+                "auto_start": false,
+                "opened_by": null,
+                "monitors": [],
+                "recordable": false,
+                "recorded": false,
+                "recorded_by": null,
+                "disqualify_unready": false,
+                "allow_comments": true,
+                "hide_comments": false,
+                "hide_entrants": false,
+                "chat_restricted": false,
+                "allow_midrace_chat": true,
+                "allow_non_entrant_chat": true,
+                "chat_message_delay": "P0DT0H0M0S",
+                "bot_meta": {}
+            }),
+        ] {
+            let serde_json::Value::Object(part) = part else { unreachable!() };
+            data.extend(part);
+        }
+        serde_json::Value::Object(data)
+    }
+
+    fn context(
+        ws_conn: tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>,
+        host_info: HostInfo,
+        state: Arc<TestState>,
+        network_timeout: UDuration,
+    ) -> (WsStream, RaceContext<TestState>, Arc<Mutex<BotData>>) {
+        let (sink, stream) = ws_conn.split();
+        let race_data = serde_json::from_value(race_data_json("in_progress")).expect("invalid test race data");
+        let ctx = RaceContext {
+            global_state: state,
+            data: Arc::new(RwLock::new(race_data)),
+            sender: Arc::new(Mutex::new(sink)),
+            network_timeout: Some(network_timeout),
+        };
+        let data = Arc::new(Mutex::new(BotData {
+            host_info,
+            category_slug: "test".to_owned(),
+            handled_races: HashSet::from(["test/test-room".to_owned()]),
+            client_id: "client".to_owned(),
+            client_secret: "secret".to_owned(),
+            access_token: "token".to_owned(),
+            reauthorize_every: UDuration::from_hours(1),
+        }));
+        (stream, ctx, data)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn server_keepalives_do_not_trigger_liveness_probes() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("failed to bind test listener");
+        let port = listener.local_addr().expect("test listener has no address").port();
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let (server_result, client_result) = tokio::join!(
+            async {
+                let (tcp_stream, _) = listener.accept().await.expect("failed to accept initial connection");
+                accept_async(tcp_stream).await
+            },
+            connect_async(&url),
+        );
+        let mut server_stream = server_result.expect("failed to accept initial WebSocket");
+        let (client_stream, _) = client_result.expect("failed to connect initial WebSocket");
+        let network_timeout = UDuration::from_millis(50);
+        let state = Arc::new(TestState::default());
+        let host_info = HostInfo {
+            hostname: Cow::Borrowed("127.0.0.1"),
+            port: NonZeroU16::new(port).expect("test listener chose port 0"),
+            secure: false,
+        };
+        let (stream, ctx, data) = context(client_stream, host_info, Arc::clone(&state), network_timeout);
+        let handle_task = tokio::spawn(async move {
+            Bot::<TestState>::handle::<TestHandler>(stream, Some(network_timeout), ctx, &data).await
+        });
+        let server_task = tokio::spawn(async move {
+            for payload in [b"one".as_slice(), b"two", b"three"] {
+                sleep(network_timeout / 2).await;
+                server_stream.send(tungstenite::Message::Ping(payload.to_vec().into())).await.expect("failed to send server keepalive");
+                let response = server_stream.next().await;
+                assert!(
+                    matches!(&response, Some(Ok(tungstenite::Message::Pong(response))) if response == payload),
+                    "client sent an unexpected frame instead of the keepalive response: {response:?}",
+                );
+            }
+            let message = serde_json::json!({
+                "type": "race.data",
+                "race": race_data_json("finished")
+            });
+            server_stream.send(tungstenite::Message::Text(message.to_string().into())).await.expect("failed to send finished race data");
+        });
+
+        for _ in 0..100 {
+            advance(network_timeout / 10).await;
+            for _ in 0..4 {
+                tokio::task::yield_now().await;
+            }
+            if handle_task.is_finished() && server_task.is_finished() {
+                break
+            }
+        }
+
+        assert!(handle_task.is_finished() && server_task.is_finished(), "healthy WebSocket test did not finish");
+        server_task.await.expect("test WebSocket server panicked");
+        handle_task.await.expect("race handler panicked").expect("race handler errored");
+        assert!(state.ended.load(Ordering::SeqCst), "handler did not process the finished race");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn silent_connection_reconnects_until_fresh_race_data_arrives() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.expect("failed to bind test listener");
+        let port = listener.local_addr().expect("test listener has no address").port();
+        let url = format!("ws://127.0.0.1:{port}/ws");
+        let (server_result, client_result) = tokio::join!(
+            async {
+                let (tcp_stream, _) = listener.accept().await.expect("failed to accept initial connection");
+                accept_async(tcp_stream).await
+            },
+            connect_async(&url),
+        );
+        let initial_server_stream = server_result.expect("failed to accept initial WebSocket");
+        let (client_stream, _) = client_result.expect("failed to connect initial WebSocket");
+        let network_timeout = UDuration::from_millis(50);
+        let state = Arc::new(TestState::default());
+        let host_info = HostInfo {
+            hostname: Cow::Borrowed("127.0.0.1"),
+            port: NonZeroU16::new(port).expect("test listener chose port 0"),
+            secure: false,
+        };
+        let (stream, ctx, data) = context(client_stream, host_info, Arc::clone(&state), network_timeout);
+        let handle_task = tokio::spawn(async move {
+            Bot::<TestState>::handle::<TestHandler>(stream, Some(network_timeout), ctx, &data).await
+        });
+        let server_task = tokio::spawn(async move {
+            let _initial_server_stream = initial_server_stream; // keep the silent connection open
+
+            let (stalled_tcp_stream, _) = listener.accept().await.expect("failed to accept stalled reconnect");
+            sleep(network_timeout * 2).await; // force the full reconnect handshake to time out
+            drop(stalled_tcp_stream);
+
+            let (tcp_stream, _) = listener.accept().await.expect("failed to accept successful reconnect");
+            let mut server_stream = accept_async(tcp_stream).await.expect("failed to accept reconnected WebSocket");
+            let message = serde_json::json!({
+                "type": "race.data",
+                "race": race_data_json("finished")
+            });
+            server_stream.send(tungstenite::Message::Text(message.to_string().into())).await.expect("failed to send fresh race data");
+        });
+
+        for _ in 0..1_000 {
+            advance(UDuration::from_millis(10)).await;
+            for _ in 0..4 {
+                tokio::task::yield_now().await;
+            }
+            if handle_task.is_finished() && server_task.is_finished() {
+                break
+            }
+        }
+
+        assert!(handle_task.is_finished() && server_task.is_finished(), "reconnect test did not finish");
+        server_task.await.expect("test WebSocket server panicked");
+        handle_task.await.expect("race handler panicked").expect("race handler errored");
+        assert!(state.ended.load(Ordering::SeqCst), "handler did not process the fresh finished race data");
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -53,7 +53,10 @@ impl<S: Send + Sync + ?Sized + 'static> BotBuilder<'_, '_, '_, S> {
         Self { scan_races_every, ..self }
     }
 
-    /// Consider it an error if any network operation (HTTP request or WebSocket read/write) takes longer than this.
+    /// Consider it an error if any network operation (HTTP request or WebSocket write) takes longer than this.
+    ///
+    /// After a WebSocket read is silent for this long, the bot sends one liveness probe. If the connection remains silent
+    /// for another interval, it reconnects. No probes are sent while the server's normal keepalive messages are arriving.
     /// Defaults to 1 hour.
     pub fn network_timeout(self, network_timeout: Option<UDuration>) -> Self {
         Self { network_timeout, ..self }


### PR DESCRIPTION
When racetime does not respond with a drop / reset, but simply times out, the handler times out after 1 hour, but no reconnect is fired.
This adds a basic health ping to make sure the elasped loop does not run endlessly.